### PR TITLE
控制台输出详细报错信息

### DIFF
--- a/script_LuaTask/lib/console.lua
+++ b/script_LuaTask/lib/console.lua
@@ -95,11 +95,12 @@ local function main_loop()
             -- 用xpcall执行用户输入的脚本，可以捕捉脚本的错误
             xpcall(function()
                 -- 执行用户输入的脚本
-                local f = loadstring(line)
+                local f = assert(loadstring(line))
                 setfenv(f, execute_env)
                 f()
             end,
-                function() -- 错误输出
+                function(err) -- 错误输出
+                    write(err .. '\r\n')
                     write(debug.traceback())
                 end)
             if wait_event_flag then


### PR DESCRIPTION
使用assert可以捕获到loadstring的详细报错信息，并通过回调打印出来。

注意，loadstring()加载类似【a=10】这种单条赋值语句时候，需要在后面追加空格字符，以避免报错“malformed number...”。